### PR TITLE
Fix allowed packages documentation formatting

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -111,3 +111,4 @@ xgbxml
 xlrd
 xlutils
 xlwt
+

--- a/Documentation/Allowed-Python-Packages.md
+++ b/Documentation/Allowed-Python-Packages.md
@@ -1,8 +1,7 @@
 
 # Allowed Python Packages
 
-The `ALLOWED_PYTHON_PACKAGES` file lists Python  
-packages that addons can request to be installed.
+The `ALLOWED_PYTHON_PACKAGES.txt` file lists Python packages that addons can request to be installed.
 
 New packages can be added by opening an [Issue].
 
@@ -10,11 +9,8 @@ New packages can be added by opening an [Issue].
 
 ## Format
 
-The config doesn't follow any Python manifest formats,  
-it's just a simple text file where each line that isn't empty  
-and not a comment is interpreted as a Python package.
+The configuration doesn't follow any Python manifest format; it's just a simple text file where each non-empty and non-comment line is interpreted as a Python package.
 
 Packages cannot be declared with a version nor wildcards.
-
 
 [Issue]: https://github.com/FreeCAD/FreeCAD-addons/issues/new/choose


### PR DESCRIPTION
## Summary
- clarify reference to `ALLOWED_PYTHON_PACKAGES.txt`
- ensure allowed packages list ends with a newline

## Testing
- `pre-commit run --files Documentation/Allowed-Python-Packages.md ALLOWED_PYTHON_PACKAGES.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a08ecc083329c423e81c28c7e4c